### PR TITLE
Updates gulp zip task to accept a specific module to build

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,13 +17,18 @@ function tplCache(item) {
 }
 
 gulp.task('zip', function () {
-  var output = merge();
-  var inputModule = argv.module;
+  var output = merge(),
+      inputModule = argv.module,
+      directories = fs.readdirSync('./modules/');
 
   if (inputModule) {
-    gulp.src([
-      './modules/' + inputModule + '/**/*',
-      '!./modules/' + inputModule + '/test/*'
+    directories = [inputModule];
+  }
+  directories.forEach(function(item) {
+
+    var stream = gulp.src([
+        './modules/' + item + '/**/*',
+        '!./modules/' + item + '/test/*'
       ])
       .pipe(
         gulpPlugin.if('*.less', gulpPlugin.less())
@@ -32,32 +37,13 @@ gulp.task('zip', function () {
         gulpPlugin.if('*.js', gulpPlugin.ngAnnotate())
       )
       .pipe(
-        gulpPlugin.if('*.html', tplCache(inputModule))
+        gulpPlugin.if('*.html', tplCache(item))
       )
-      .pipe(gulpPlugin.zip(inputModule + '.zip'))
+      .pipe(gulpPlugin.zip(item + '.zip'))
       .pipe(gulp.dest('./zip/'));
-  } else {
-    fs.readdirSync('./modules/').forEach(function(item) {
 
-      var stream = gulp.src([
-          './modules/' + item + '/**/*',
-          '!./modules/' + item + '/test/*'
-        ])
-        .pipe(
-          gulpPlugin.if('*.less', gulpPlugin.less())
-        )
-        .pipe(
-          gulpPlugin.if('*.js', gulpPlugin.ngAnnotate())
-        )
-        .pipe(
-          gulpPlugin.if('*.html', tplCache(item))
-        )
-        .pipe(gulpPlugin.zip(item + '.zip'))
-        .pipe(gulp.dest('./zip/'));
-
-        output = merge(output, stream);
-    });
-  }
+      output = merge(output, stream);
+  });
   return output;
 });
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp'),
     merge = require('merge-stream'),
     jshint = require('gulp-jshint'),
     karma = require('karma').server,
+    argv = require('yargs').argv,
     path = require('path');
 
 
@@ -15,13 +16,14 @@ function tplCache(item) {
   });
 }
 
-gulp.task('zip', ['clean'], function () {
+gulp.task('zip', function () {
   var output = merge();
-  fs.readdirSync('./modules/').forEach(function(item) {
+  var inputModule = argv.module;
 
-    var stream = gulp.src([
-        './modules/' + item + '/**/*',
-        '!./modules/' + item + '/test/*'
+  if (inputModule) {
+    gulp.src([
+      './modules/' + inputModule + '/**/*',
+      '!./modules/' + inputModule + '/test/*'
       ])
       .pipe(
         gulpPlugin.if('*.less', gulpPlugin.less())
@@ -30,13 +32,32 @@ gulp.task('zip', ['clean'], function () {
         gulpPlugin.if('*.js', gulpPlugin.ngAnnotate())
       )
       .pipe(
-        gulpPlugin.if('*.html', tplCache(item))
+        gulpPlugin.if('*.html', tplCache(inputModule))
       )
-      .pipe(gulpPlugin.zip(item + '.zip'))
+      .pipe(gulpPlugin.zip(inputModule + '.zip'))
       .pipe(gulp.dest('./zip/'));
+  } else {
+    fs.readdirSync('./modules/').forEach(function(item) {
 
-      output = merge(output, stream);
-  });
+      var stream = gulp.src([
+          './modules/' + item + '/**/*',
+          '!./modules/' + item + '/test/*'
+        ])
+        .pipe(
+          gulpPlugin.if('*.less', gulpPlugin.less())
+        )
+        .pipe(
+          gulpPlugin.if('*.js', gulpPlugin.ngAnnotate())
+        )
+        .pipe(
+          gulpPlugin.if('*.html', tplCache(item))
+        )
+        .pipe(gulpPlugin.zip(item + '.zip'))
+        .pipe(gulp.dest('./zip/'));
+
+        output = merge(output, stream);
+    });
+  }
   return output;
 });
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "karma": "^0.12.24",
     "karma-chrome-launcher": "^0.1.5",
     "karma-jasmine": "^0.2.3",
-    "merge-stream": "^0.1.6"
+    "merge-stream": "^0.1.6",
+    "yargs": "^1.3.2"
   }
 }


### PR DESCRIPTION
Allows developers to do this,

``` javascript
gulp zip --module cask-angular-dropdown-text-combo
```

This builds only dropdown-text-combo zip file and not everything else. Cleaning everything when we update one single module seems to be redundant.
