### PR TITLE
Feature/ui observable promises

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,6 +6,7 @@ var gulp = require('gulp'),
     jshint = require('gulp-jshint'),
     karma = require('karma').Server,
     argv = require('yargs').argv,
+    install = require('gulp-install'),
     path = require('path');
 
 
@@ -55,6 +56,9 @@ gulp.task('clean', function(cb) {
 gulp.task('test-build', function(cb) {
   var modules = fs.readdirSync('./modules/');
   modules.forEach(function(item) {
+    gulp.src('./modules/'+ item + '/bower.json')
+      .pipe(install());
+
     gulp.src([
       './modules/' + item + '/**/*.html'
     ])

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -69,7 +69,8 @@ gulp.task('test-build', function(cb) {
 
 gulp.task('jshint', function() {
   return gulp.src([
-    './modules/**/*.js'
+    './modules/**/*.js',
+    '!./modules/**/bower_components/**/*.js'
     ])
     .pipe(jshint())
     .pipe(jshint.reporter())

--- a/modules/cask-angular-socket-datasource/bower.json
+++ b/modules/cask-angular-socket-datasource/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "cask-angular-socket-datasource",
+  "main": [
+    "module.js",
+    "socket.js",
+    "datasource.js"
+  ],
+  "version": "0.0.1",
+  "description": "A provider that is used to setup socket connection and seemlesly communicate between backend and different controllers in different modules.",
+  "keywords": [ 
+    "Sockets",
+    "SOCKJS",
+    "DataSource",
+    "angular-service"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular": "1.x",
+    "cask-angular-observable-promise": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-observable-promise.zip",
+    "cask-angular-eventpipe": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-eventpipe.zip",
+    "cask-angular-window-manager": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-window-manager.zip",
+    "sockjs-client": "1.0.2",
+    "node-uuid": "1.4.3"
+  }
+}

--- a/modules/cask-angular-socket-datasource/datasource.js
+++ b/modules/cask-angular-socket-datasource/datasource.js
@@ -1,0 +1,410 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+var socketDataSource = angular.module('cask-angular-socket-datasource');
+
+  /**
+    Example Usage:
+
+    MyCDAPDataSource // usage in a controller:
+
+    var dataSrc = new MyCDAPDataSource($scope);
+
+    // polling a namespaced resource example:
+    dataSrc.poll({
+        method: 'GET',
+        _cdapNsPath: '/foo/bar',
+        interval: 5000 // in milliseconds.
+      },
+      function(result) {
+        $scope.foo = result;
+      }
+    ); // will poll <host>:<port>/v3/namespaces/<currentNamespace>/foo/bar
+
+    // posting to a systemwide resource:
+    dataSrc.request({
+        method: 'POST',
+        _cdapPath: '/system/config',
+        body: {
+          foo: 'bar'
+        }
+      },
+      function(result) {
+        $scope.foo = result;
+      }
+    ); // will post to <host>:<port>/v3/system/config
+
+   */
+
+  socketDataSource.factory('uuid', function ($window) {
+    return $window.uuid;
+  });
+
+
+  socketDataSource.provider('MyDataSource', function () {
+
+    this.defaultPollInterval = 10;
+
+    this.$get = function($rootScope, caskWindowManager, mySocket, MYSOCKET_EVENT, $q, MyPromise, uuid, EventPipe) {
+
+      var instances = {}; // keyed by scopeid
+
+      /**
+       * Start polling of the resource - sends the action 'poll-start' to
+       * the node backend.
+       */
+      function _pollStart (resource) {
+        var re = {};
+        if (!resource.url) {
+          re = resource;
+        }else {
+          re = {
+            id: resource.id,
+            url: resource.url,
+            json: resource.json,
+            method: resource.method
+          };
+          if (resource.interval) {
+            re.interval = resource.interval;
+          }
+          if (resource.body) {
+            re.body = resource.body;
+          }
+        }
+
+        if (resource.headers) {
+          re.headers = resource.headers;
+        }
+
+        mySocket.send({
+          action: 'poll-start',
+          resource: re
+        });
+      }
+
+      /**
+       * Stops polling of the resource - sends the actions 'poll-stop' to
+       * the node backend.
+       */
+      function _pollStop (resource) {
+        var re = {};
+        if (!resource.url) {
+          re = resource;
+        }else {
+          re = {
+            id: resource.id,
+            url: resource.url,
+            json: resource.json,
+            method: resource.method
+          };
+        }
+        if (resource.header) {
+          re.header = resource.header;
+        }
+
+        mySocket.send({
+          action: 'poll-stop',
+          resource: re
+        });
+      }
+
+
+      function DataSource (scope) {
+        scope = scope || $rootScope.$new();
+
+        var id = scope.$id,
+            self = this;
+
+        if(instances[id]) {
+          // Reuse the same instance if already created.
+          return instances[id];
+        }
+
+        if (!(this instanceof DataSource)) {
+          return new DataSource(scope);
+        }
+        instances[id] = self;
+
+        this.scopeId = id;
+        this.bindings = {};
+
+        EventPipe.on(MYSOCKET_EVENT.message, function (data) {
+          var hash;
+          hash = data.resource.id;
+
+          if(data.statusCode>299 || data.warning) {
+            if (self.bindings[hash]) {
+              if(self.bindings[hash].errorCallback) {
+                $rootScope.$apply(self.bindings[hash].errorCallback.bind(null, data.response));
+              } else if (self.bindings[hash].reject) {
+                $rootScope.$apply(self.bindings[hash].reject.bind(null, {data: data.response}));
+              }
+            }
+            return; // errors are handled at $rootScope level
+          }
+
+          if (self.bindings[hash]) {
+            if (self.bindings[hash].callback) {
+              data.response = data.response || {};
+              data.response.__pollId__ = hash;
+              scope.$apply(self.bindings[hash].callback.bind(null, data.response));
+            } else if (self.bindings[hash].resolve) {
+              // https://github.com/angular/angular.js/wiki/When-to-use-$scope.$apply%28%29
+              scope.$apply(self.bindings[hash].resolve.bind(null, {data: data.response, id: hash}));
+              return;
+            }
+          }
+
+        });
+
+        scope.$on('$destroy', function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStop(b.resource);
+            }
+          });
+
+          delete instances[self.scopeId];
+        });
+
+        scope.$on(caskWindowManager.event.blur, function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStop(b.resource);
+            }
+          });
+        });
+
+        scope.$on(caskWindowManager.event.focus, function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStart(b.resource);
+            }
+          });
+        });
+
+      }
+
+      /**
+       * Start polling of a resource when in scope.
+       */
+      DataSource.prototype.poll = function (resource, cb, errorCb) {
+        var self = this;
+        var generatedResource = {};
+        var promise = new MyPromise(function(resolve, reject) {
+          generatedResource = {
+            json: resource.json,
+            interval: resource.interval || (resource.options &&  resource.options.interval) || $rootScope.defaultPollInterval,
+            body: resource.body,
+            method: resource.method || 'GET'
+          };
+
+          if (resource.headers) {
+            generatedResource.headers = resource.headers;
+          }
+
+          generatedResource.url = buildUrl(resource.url, resource.params || {});
+          generatedResource.id = uuid.v4();
+          self.bindings[generatedResource.id] = {
+            poll: true,
+            callback: cb,
+            resource: generatedResource,
+            errorCallback: errorCb,
+            resolve: resolve,
+            reject: reject
+          };
+
+          _pollStart(generatedResource);
+        }, true);
+
+        if (!resource.$isResource) {
+          promise = promise.then(function(res) {
+            res = res.data;
+            res.__pollId__ = generatedResource.id;
+            return $q.when(res);
+          });
+        }
+        promise.__pollId__ = generatedResource.id;
+        return promise;
+      };
+
+      /**
+       * Stop polling of a resource when requested.
+       * (when scope is destroyed Line 196 takes care of deleting the polling resource)
+       */
+      DataSource.prototype.stopPoll = function(resourceId) {
+        // Duck Typing for angular's $resource.
+        var defer = $q.defer();
+        var id, resource;
+        if (angular.isObject(resourceId)) {
+          id = resourceId.params.pollId;
+        } else {
+          id = resourceId;
+        }
+
+        var match = this.bindings[resourceId];
+
+        if (match) {
+          resource = match.resource;
+          _pollStop(resource);
+          delete this.bindings[resourceId];
+          defer.resolve({});
+        } else {
+          defer.reject({});
+        }
+        return defer.promise;
+      };
+
+      /**
+       * Fetch a template configuration on-demand. Send the action
+       * 'template-config' to the node backend.
+       */
+      DataSource.prototype.config = function (resource, cb) {
+        var deferred = $q.defer();
+
+        resource.suppressErrors = true;
+        resource.id = uuid.v4();
+        this.bindings[resource.id] = {
+          resource: resource,
+          callback: function (result) {
+            if (cb) {
+              cb.apply(this, arguments);
+            }
+            deferred.resolve(result);
+          },
+          errorCallback: function(err) {
+            deferred.reject(err);
+          }
+        };
+
+        mySocket.send({
+          action: resource.actionName,
+          resource: resource
+        });
+        return deferred.promise;
+      };
+
+      /**
+       * Fetch a resource on-demand. Send the action 'request' to
+       * the node backend.
+       */
+      DataSource.prototype.request = function (resource, cb) {
+        var self = this;
+        var promise = new MyPromise(function(resolve, reject) {
+
+          var generatedResource = {
+            json: resource.json,
+            method: resource.method || 'GET'
+          };
+          if (resource.body) {
+            generatedResource.body = resource.body;
+          }
+
+          if (resource.data) {
+            generatedResource.body = resource.data;
+          }
+
+          if (resource.headers) {
+            generatedResource.headers = resource.headers;
+          }
+          if (resource.contentType) {
+            generatedResource.headers['Content-Type'] = resource.contentType;
+          }
+
+          generatedResource.url = buildUrl(resource.url, resource.params || {});
+          generatedResource.id = uuid.v4();
+          self.bindings[generatedResource.id] = {
+            callback: cb,
+            resource: generatedResource,
+            resolve: resolve,
+            reject: reject
+          };
+
+          mySocket.send({
+            action: 'request',
+            resource: generatedResource
+          });
+        }, false);
+
+        if (!resource.$isResource) {
+          promise = promise.then(function(res) {
+            res = res.data;
+            return $q.when(res);
+          });
+        }
+
+        return promise;
+      };
+
+      return DataSource;
+
+    };
+
+
+  });
+
+// Lifted from $http as a helper method to parse '@params' in the url for $resource.
+function buildUrl(url, params) {
+  if (!params) {
+    return url;
+  }
+  var parts = [];
+
+  function forEachSorted(obj, iterator, context) {
+    var keys = Object.keys(params).sort();
+    for (var i = 0; i < keys.length; i++) {
+      iterator.call(context, obj[keys[i]], keys[i]);
+    }
+    return keys;
+  }
+
+  function encodeUriQuery(val, pctEncodeSpaces) {
+    return encodeURIComponent(val).
+           replace(/%40/gi, '@').
+           replace(/%3A/gi, ':').
+           replace(/%24/g, '$').
+           replace(/%2C/gi, ',').
+           replace(/%3B/gi, ';').
+           replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
+  }
+
+  forEachSorted(params, function(value, key) {
+    if (value === null || angular.isUndefined(value)) {
+      return;
+    }
+    if (!angular.isArray(value)) {
+      value = [value];
+    }
+
+    angular.forEach(value, function(v) {
+      if (angular.isObject(v)) {
+        if (angular.isDate(v)) {
+          v = v.toISOString();
+        } else {
+          v = angular.toJson(v);
+        }
+      }
+      parts.push(encodeUriQuery(key) + '=' + encodeUriQuery(v));
+    });
+  });
+  if (parts.length > 0) {
+    url += ((url.indexOf('?') === -1) ? '?' : '&') + parts.join('&');
+  }
+  return url;
+}

--- a/modules/cask-angular-socket-datasource/module.js
+++ b/modules/cask-angular-socket-datasource/module.js
@@ -1,0 +1,5 @@
+angular.module('cask-angular-socket-datasource', [
+  'cask-angular-eventpipe',
+  'cask-angular-window-manager',
+  'cask-angular-observable-promise'
+]);

--- a/modules/cask-angular-socket-datasource/socket.js
+++ b/modules/cask-angular-socket-datasource/socket.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module('cask-angular-socket-datasource')
+
+.factory('SockJS', function ($window) {
+  return $window.SockJS;
+})
+
+.constant('MYSOCKET_EVENT', {
+  message: 'mysocket-message',
+  closed: 'mysocket-closed',
+  reconnected: 'mysocket-reconnected'
+})
+
+.provider('mySocket', function () {
+
+  this.prefix = '/_sock';
+
+  this.$get = function (MYSOCKET_EVENT, SockJS, $log, EventPipe) {
+
+    var self = this,
+        socket = null,
+        buffer = [];
+
+    function init (attempt) {
+      $log.log('[mySocket] init');
+
+      attempt = attempt || 1;
+      socket = new SockJS(self.prefix);
+
+      socket.onmessage = function (event) {
+        try {
+          var data = JSON.parse(event.data);
+          $log.debug('[mySocket] ←', data);
+          EventPipe.emit(MYSOCKET_EVENT.message, data);
+        }
+        catch(e) {
+          $log.error(e);
+        }
+      };
+
+      socket.onopen = function (event) {
+        EventPipe.emit('backendUp', 'User interface service is online');
+        if(attempt>1) {
+          EventPipe.emit(MYSOCKET_EVENT.reconnected, event);
+          attempt = 1;
+        }
+
+        $log.info('[mySocket] opened');
+        angular.forEach(buffer, send);
+        buffer = [];
+      };
+
+      socket.onclose = function (event) {
+        $log.error(event.reason);
+        EventPipe.emit('backendDown', 'User interface service is down');
+
+        if(attempt<2) {
+          EventPipe.emit(MYSOCKET_EVENT.closed, event);
+        }
+
+        // reconnect with exponential backoff
+        var d = Math.max(500, Math.round(
+          (Math.random() + 1) * 500 * Math.pow(2, attempt)
+        ));
+        $log.log('[mySocket] will try again in ',d+'ms');
+        setTimeout(function () {
+          init(attempt+1);
+        }, d);
+      };
+
+    }
+
+    function send(obj) {
+      if(!socket.readyState) {
+        buffer.push(obj);
+        return false;
+      }
+
+      doSend(obj);
+
+      return true;
+    }
+
+    function doSend(obj) {
+      var msg = obj,
+          r = obj.resource;
+
+      if(r) {
+        msg.resource = r;
+
+        // Majority of the time, we send data as json and expect a json response, but not always (i.e. stream ingest).
+        // Default to json content-type.
+        if (msg.resource.json === undefined) {
+          msg.resource.json = true;
+        }
+
+        if (!r.method) {
+          msg.resource.method = 'GET';
+        }
+
+        $log.debug('[mySocket] →', msg.action, r.method, r.url);
+      }
+
+      socket.send(JSON.stringify(msg));
+    }
+
+    init();
+
+    return {
+      init: init,
+      send: send,
+      close: function () {
+        return socket.close.apply(socket, arguments);
+      }
+    };
+  };
+
+});

--- a/modules/cask-angular-socket-datasource/test/socket-datasource-test.js
+++ b/modules/cask-angular-socket-datasource/test/socket-datasource-test.js
@@ -1,0 +1,158 @@
+describe('Unit test for MyDataSource + MySocket', function() {
+  var MySocket,
+      EventPipe1,
+      MyDataSource1,
+      $rootScope1,
+      resourceId,
+      scope, dataSrc,url,
+      $timeout,
+      MYSOCKET_EVENT1;
+  beforeEach(module('cask-angular-eventpipe'));
+  beforeEach(module('cask-angular-window-manager'));
+  beforeEach(module('cask-angular-observable-promise'));
+  beforeEach(function () {
+    module('cask-angular-socket-datasource', function($provide) {
+      $provide.value('$window', window);
+    });
+    try {
+      inject(function(MyDataSource, mySocket, MYSOCKET_EVENT, EventPipe, $rootScope, _$timeout_) {
+        EventPipe1 = EventPipe;
+        $rootScope1 = $rootScope;
+        MySocket = mySocket;
+        MyDataSource1 = MyDataSource;
+        $timeout  = _$timeout_;
+        MYSOCKET_EVENT1 = MYSOCKET_EVENT;
+
+        scope  = $rootScope1.$new();
+        dataSrc = new MyDataSource1(scope);
+        url = 'http://localhost:8080/apps/myAppId';
+
+        spyOn(MySocket, 'send').andCallFake(function(re) {
+          resourceId = re.resource.id;
+          if (re.poll) {
+
+          }
+          return re.resource.url;
+        });
+        spyOn(MySocket, 'close').andCallFake(function() {
+          return 'Socket Connection Closed';
+        });
+      });
+    } catch(e){
+      console.log(e);
+    }
+  });
+
+  describe('Request - Success:Failure cases', function() {
+    it ('Success case - 200 OK from backend', function () {
+      dataSrc.request({
+        url: url
+      })
+        .then(
+          function success(res) {
+            expect(res.data).toBe(url);
+          }
+        );
+
+      EventPipe1.emit(MYSOCKET_EVENT1.message, {
+        resource: {
+          id: resourceId
+        },
+        response: {
+          data: url
+        }
+      });
+    });
+
+    it('Failure case - 500 Internal server error from backend', function() {
+      dataSrc.request({
+        url: url
+      })
+        .then(
+          function success(res) {
+
+          },
+          function error(err) {
+            expect(err.data).toBe('ERROR');
+          }
+        );
+
+        EventPipe1.emit(MYSOCKET_EVENT1.message, {
+          resource: {
+            id: resourceId
+          },
+          response: 'ERROR',
+          statusCode: 500
+        });
+    });
+  });
+  describe('Poll - Success:Failre cases', function() {
+
+    it('Success case - 200 OK from backend', function () {
+      dataSrc.poll({
+        url: url
+      })
+        .then(
+          function success(res) {
+            if (res.data.j === 10) {
+              expect(res.data.url).toBe(url);
+              expect(res.data.j).toBe(10);
+            }
+          },
+          function error(){}
+        );
+        $timeout(function() {
+          var j;
+          for (j=0; j<=10; j++) {
+            EventPipe1.emit(MYSOCKET_EVENT1.message, {
+              resource: {
+                id: resourceId
+              },
+              response: {
+                data: {
+                  url: url,
+                  j: j
+                }
+              }
+            });
+          }
+        });
+        $timeout.flush();
+    });
+
+    it('Failure case - 500 Internal server error from backend', function () {
+      dataSrc.poll({
+        url: url
+      })
+        .then(
+          function success(res) {
+          },
+          function error(){
+            if (res.data.j === 10) {
+              expect(res.data.message).toBe('ERROR');
+              expect(res.data.j).toBe(10);
+            }
+          }
+        );
+        $timeout(function() {
+          var j;
+          for (j=0; j<=10; j++) {
+            EventPipe1.emit(MYSOCKET_EVENT1.message, {
+              resource: {
+                id: resourceId
+              },
+              response: {
+                data: {
+                  message: 'ERROR',
+                  j: j
+                }
+              },
+              statusCode: 500
+            });
+          }
+        });
+        $timeout.flush();
+    });
+
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "karma-jasmine": "0.1.6",
     "karma-mocha-reporter": "1.1.1",
     "merge-stream": "^0.1.6",
-    "yargs": "^1.3.2"
+    "yargs": "^1.3.2",
+    "gulp-install": "^0.6.0"
   }
 }

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -5,7 +5,8 @@ module.exports = function(config) {
       '../bower_components/angular/angular.js',
       '../bower_components/angular-mocks/angular-mocks.js',
       '../bower_components/jquery/dist/jquery.js',
-
+      '../modules/cask-angular-socket-datasource/bower_components/sockjs-client/dist/sockjs.js',
+      '../modules/cask-angular-socket-datasource/bower_components/node-uuid/uuid.js',
 
       '*/module.js',
       '**/test/templates/tpl.html.js',


### PR DESCRIPTION
- Adds `mySocket` and `MyDataSource`` providers.
  - The `cask-angular-socket-datasource` module's providers are originally used in CDAP for communicating with backend (through node-proxy). Right the client code is extracted out so that it could be used as a bower component. 
  - TODO: The node part of the socket setup has to be moved out too. That would be the next step to completely isolate the solution from actual CDAP code (to be re-used in any cask projects)
- Modifies karma config and the way we test modules. (bower component come into play).
